### PR TITLE
updated requirements to allow Python 3.11

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -15,11 +15,6 @@ jobs:
   timeoutInMinutes: 360
 
   steps:
-  - script: |
-         rm -rf /opt/ghc
-         df -h
-    displayName: Manage disk space
-
   # configure qemu binfmt-misc running.  This allows us to run docker containers
   # embedded qemu-static
   - script: |

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -31,11 +31,10 @@ pkgs_dirs:
 
 CONDARC
 
-
-mamba install --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
-mamba update --update-specs --yes --quiet --channel conda-forge \
-    conda-build pip boa conda-forge-ci-setup=3
+mamba install --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
+mamba update --update-specs --yes --quiet --channel conda-forge --strict-channel-priority \
+    pip mamba conda-build boa conda-forge-ci-setup=3
 
 # set up the condarc
 setup_conda_rc "${FEEDSTOCK_ROOT}" "${RECIPE_ROOT}" "${CONFIG_FILE}"

--- a/.scripts/logging_utils.sh
+++ b/.scripts/logging_utils.sh
@@ -12,7 +12,7 @@ function startgroup {
             echo "##[group]$1";;
         travis )
             echo "$1"
-            echo -en 'travis_fold:start:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:start:'"${1// /}"'\r';;
         github_actions )
             echo "::group::$1";;
         * )
@@ -28,7 +28,7 @@ function endgroup {
         azure )
             echo "##[endgroup]";;
         travis )
-            echo -en 'travis_fold:end:'"${1// /}"'\\r';;
+            echo -en 'travis_fold:end:'"${1// /}"'\r';;
         github_actions )
             echo "::endgroup::";;
     esac

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,14 +11,14 @@ source:
 build:
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
-  number: 0
+  number: 1
 
 requirements:
   host:
-    - python >=3.8,<3.11
+    - python >=3.8,<3.12
     - pip
   run:
-    - python >=3.8,<3.11
+    - python >=3.8,<3.12
     - pip
     - numpy >=1.20
     - scipy


### PR DESCRIPTION
Will merge in conjunction with https://github.com/sandialabs/WecOptTool/pull/278.
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
